### PR TITLE
SLING-13259 - OakDiscoveryService: skip property update during framework shutdown

### DIFF
--- a/src/main/java/org/apache/sling/discovery/oak/OakDiscoveryService.java
+++ b/src/main/java/org/apache/sling/discovery/oak/OakDiscoveryService.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.sling.api.resource.LoginException;
@@ -116,7 +117,7 @@ public class OakDiscoveryService extends BaseDiscoveryService {
     /**
      * Cached system bundle (bundle 0), resolved once at activation.
      */
-    private volatile Bundle systemBundle;
+    private final AtomicReference<Bundle> systemBundle = new AtomicReference<>();
 
     @Reference
     private ResourceResolverFactory resourceResolverFactory;
@@ -612,7 +613,7 @@ public class OakDiscoveryService extends BaseDiscoveryService {
         if (deactivating) {
             return true;
         }
-        final Bundle sb = systemBundle;
+        final Bundle sb = systemBundle.get();
         if (sb == null) {
             return false;
         }
@@ -641,7 +642,7 @@ public class OakDiscoveryService extends BaseDiscoveryService {
      * through {@link #cacheSystemBundle()}.
      */
     void setSystemBundleForTesting(final Bundle bundle) {
-        this.systemBundle = bundle;
+        this.systemBundle.set(bundle);
     }
 
     private void cacheSystemBundle() {
@@ -666,7 +667,7 @@ public class OakDiscoveryService extends BaseDiscoveryService {
                         + " - shutdown detection degrades to deactivate() only");
                 return;
             }
-            systemBundle = ctx.getBundle(0);
+            systemBundle.set(ctx.getBundle(0));
         } catch (IllegalStateException e) {
             logger.warn("cacheSystemBundle: BundleContext already invalidated at activation"
                     + " - marking discovery as deactivating immediately: {}", e.toString());

--- a/src/main/java/org/apache/sling/discovery/oak/OakDiscoveryService.java
+++ b/src/main/java/org/apache/sling/discovery/oak/OakDiscoveryService.java
@@ -338,7 +338,7 @@ public class OakDiscoveryService extends BaseDiscoveryService {
         // set before acquiring any lock so concurrent PropertyProvider
         // callbacks short-circuit in doUpdateProperties()
         deactivating = true;
-        logger.debug("OakDiscoveryService deactivated.");
+        logger.info("OakDiscoveryService deactivated, further updates will be suppressed");
         viewStateManagerLock.lock();
         try {
             viewStateManager.unbind(changePropagationListener);
@@ -631,7 +631,7 @@ public class OakDiscoveryService extends BaseDiscoveryService {
         } catch (IllegalStateException e) {
             deactivating = true;
             logger.info("isShuttingDown: system bundle reference invalidated - "
-                    + "OakDiscoveryService will skip further property writes");
+                    + "OakDiscoveryService will skip further property writes : {}", e.toString());
             return true;
         }
         return false;
@@ -656,14 +656,14 @@ public class OakDiscoveryService extends BaseDiscoveryService {
      */
     void cacheSystemBundle(final Bundle ourBundle) {
         if (ourBundle == null) {
-            logger.debug("cacheSystemBundle: no OSGi framework detected via FrameworkUtil"
+            logger.info("cacheSystemBundle: no OSGi framework detected via FrameworkUtil"
                     + " - shutdown detection degrades to deactivate() only");
             return;
         }
         try {
             final BundleContext ctx = ourBundle.getBundleContext();
             if (ctx == null) {
-                logger.debug("cacheSystemBundle: our BundleContext is null"
+                logger.info("cacheSystemBundle: our BundleContext is null"
                         + " - shutdown detection degrades to deactivate() only");
                 return;
             }

--- a/src/main/java/org/apache/sling/discovery/oak/OakDiscoveryService.java
+++ b/src/main/java/org/apache/sling/discovery/oak/OakDiscoveryService.java
@@ -64,8 +64,10 @@ import org.apache.sling.discovery.commons.providers.util.PropertyNameHelper;
 import org.apache.sling.discovery.commons.providers.util.ResourceHelper;
 import org.apache.sling.discovery.oak.pinger.OakViewChecker;
 import org.apache.sling.settings.SlingSettingsService;
+import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
+import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -104,6 +106,17 @@ public class OakDiscoveryService extends BaseDiscoveryService {
      * events to discovery awares before activate is done
      **/
     private volatile boolean activated = false;
+
+    /**
+     * Latched to {@code true} once this component or the OSGi framework begins
+     * shutting down. See {@link #isShuttingDown()}.
+     */
+    private volatile boolean deactivating = false;
+
+    /**
+     * Cached system bundle (bundle 0), resolved once at activation.
+     */
+    private volatile Bundle systemBundle;
 
     @Reference
     private ResourceResolverFactory resourceResolverFactory;
@@ -214,6 +227,8 @@ public class OakDiscoveryService extends BaseDiscoveryService {
     protected void activate(final BundleContext bundleContext) {
         logger.debug("OakDiscoveryService activating...");
 
+        cacheSystemBundle();
+
         if (settingsService == null) {
             throw new IllegalStateException("settingsService not found");
         }
@@ -319,6 +334,9 @@ public class OakDiscoveryService extends BaseDiscoveryService {
      */
     @Deactivate
     protected void deactivate() {
+        // set before acquiring any lock so concurrent PropertyProvider
+        // callbacks short-circuit in doUpdateProperties()
+        deactivating = true;
         logger.debug("OakDiscoveryService deactivated.");
         viewStateManagerLock.lock();
         try {
@@ -479,6 +497,10 @@ public class OakDiscoveryService extends BaseDiscoveryService {
      * @see Config#getClusterInstancesPath()
      */
     private void doUpdateProperties() {
+        if (isShuttingDown()) {
+            logger.debug("doUpdateProperties: skipping property update - service or framework is shutting down");
+            return;
+        }
         // SLING-5382 : the caller must ensure that this method
         // is not invoked after deactivation or before activation.
         // so this method doesn't have to do any further synchronization.
@@ -578,6 +600,80 @@ public class OakDiscoveryService extends BaseDiscoveryService {
             logger.debug("updateProperties: calling handlePotentialTopologyChange.");
             checkForTopologyChange();
             logger.debug("updateProperties: done.");
+        }
+    }
+
+    /**
+     * Returns {@code true} when this component or the framework is shutting
+     * down. Latches {@link #deactivating} on first observation so subsequent
+     * calls are a single volatile read. Package-private for unit testing.
+     */
+    boolean isShuttingDown() {
+        if (deactivating) {
+            return true;
+        }
+        final Bundle sb = systemBundle;
+        if (sb == null) {
+            return false;
+        }
+        try {
+            final int state = sb.getState();
+            if (state == Bundle.STOPPING
+                    || state == Bundle.RESOLVED
+                    || state == Bundle.INSTALLED
+                    || state == Bundle.UNINSTALLED) {
+                deactivating = true;
+                logger.info("isShuttingDown: system bundle state {} observed - "
+                        + "OakDiscoveryService will skip further property writes", state);
+                return true;
+            }
+        } catch (IllegalStateException e) {
+            deactivating = true;
+            logger.info("isShuttingDown: system bundle reference invalidated - "
+                    + "OakDiscoveryService will skip further property writes");
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Test-only hook to install a system-bundle reference without going
+     * through {@link #cacheSystemBundle()}.
+     */
+    void setSystemBundleForTesting(final Bundle bundle) {
+        this.systemBundle = bundle;
+    }
+
+    private void cacheSystemBundle() {
+        cacheSystemBundle(FrameworkUtil.getBundle(OakDiscoveryService.class));
+    }
+
+    /**
+     * Package-private overload taking the caller-bundle explicitly, so unit
+     * tests can exercise the {@link BundleContext} failure branches without
+     * an OSGi framework.
+     */
+    void cacheSystemBundle(final Bundle ourBundle) {
+        if (ourBundle == null) {
+            logger.debug("cacheSystemBundle: no OSGi framework detected via FrameworkUtil"
+                    + " - shutdown detection degrades to deactivate() only");
+            return;
+        }
+        try {
+            final BundleContext ctx = ourBundle.getBundleContext();
+            if (ctx == null) {
+                logger.debug("cacheSystemBundle: our BundleContext is null"
+                        + " - shutdown detection degrades to deactivate() only");
+                return;
+            }
+            systemBundle = ctx.getBundle(0);
+        } catch (IllegalStateException e) {
+            logger.warn("cacheSystemBundle: BundleContext already invalidated at activation"
+                    + " - marking discovery as deactivating immediately: {}", e.toString());
+            deactivating = true;
+        } catch (RuntimeException e) {
+            logger.warn("cacheSystemBundle: could not resolve system bundle - shutdown detection"
+                    + " has degraded to deactivate() only: {}", e.toString());
         }
     }
 

--- a/src/test/java/org/apache/sling/discovery/oak/OakDiscoveryServiceTest.java
+++ b/src/test/java/org/apache/sling/discovery/oak/OakDiscoveryServiceTest.java
@@ -24,7 +24,11 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
+import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -44,6 +48,7 @@ import org.apache.sling.discovery.base.its.setup.mock.DummyResourceResolverFacto
 import org.apache.sling.discovery.base.its.setup.mock.MockFactory;
 import org.apache.sling.discovery.base.its.setup.mock.PropertyProviderImpl;
 import org.apache.sling.discovery.commons.providers.BaseTopologyView;
+import org.apache.sling.discovery.commons.providers.ViewStateManager;
 import org.apache.sling.discovery.commons.providers.base.DummyListener;
 import org.apache.sling.discovery.commons.providers.spi.base.DescriptorHelper;
 import org.apache.sling.discovery.commons.providers.spi.base.DiscoveryLiteConfig;
@@ -60,6 +65,7 @@ import org.apache.sling.discovery.oak.its.setup.SimulatedLeaseCollection;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.osgi.framework.Bundle;
 import org.osgi.framework.Constants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -453,6 +459,141 @@ public class OakDiscoveryServiceTest {
         discoveryService.bindPropertyProvider(p, m);
         discoveryService.unbindPropertyProvider(p, m);
         discoveryService.updatedPropertyProvider(p, m);
+    }
+
+    /**
+     * After deactivate(): isShuttingDown() latches true and subsequent
+     * PropertyProvider callbacks do not reach the ResourceResolverFactory.
+     */
+    @Test
+    public void testIsShuttingDownAfterDeactivate() throws Exception {
+        OakDiscoveryService ds = new OakDiscoveryService();
+
+        // Wire only what deactivate() and the property-provider callbacks touch.
+        ViewStateManager vsmMock = mock(ViewStateManager.class);
+        Field vsmField = OakDiscoveryService.class.getDeclaredField("viewStateManager");
+        vsmField.setAccessible(true);
+        vsmField.set(ds, vsmMock);
+
+        ResourceResolverFactory rrfMock = mock(ResourceResolverFactory.class);
+        Field rrfField = OakDiscoveryService.class.getDeclaredField("resourceResolverFactory");
+        rrfField.setAccessible(true);
+        rrfField.set(ds, rrfMock);
+
+        assertFalse(ds.isShuttingDown());
+
+        ds.deactivate();
+        assertTrue(ds.isShuttingDown());
+
+        PropertyProviderImpl provider = new PropertyProviderImpl();
+        Map<String, Object> props = new HashMap<>();
+        props.put(Constants.SERVICE_ID, 42L);
+        ds.bindPropertyProvider(provider, props);
+        ds.updatedPropertyProvider(provider, props);
+        ds.unbindPropertyProvider(provider, props);
+
+        verifyNoInteractions(rrfMock);
+    }
+
+    /**
+     * The inline system-bundle-state check catches framework shutdown before
+     * deactivate() runs, and latches on first observation.
+     */
+    @Test
+    public void testInlineSystemBundleStateFallback() throws Exception {
+        OakDiscoveryService ds = new OakDiscoveryService();
+
+        Bundle systemBundleMock = mock(Bundle.class);
+        ds.setSystemBundleForTesting(systemBundleMock);
+
+        when(systemBundleMock.getState()).thenReturn(Bundle.ACTIVE);
+        assertFalse(ds.isShuttingDown());
+
+        when(systemBundleMock.getState()).thenReturn(Bundle.STOPPING);
+        assertTrue(ds.isShuttingDown());
+
+        // latched: state flipping back to ACTIVE must not un-shut-down
+        when(systemBundleMock.getState()).thenReturn(Bundle.ACTIVE);
+        assertTrue(ds.isShuttingDown());
+    }
+
+    /**
+     * An invalidated system bundle reference (IllegalStateException on
+     * getState) is treated as shutting down.
+     */
+    @Test
+    public void testInvalidatedSystemBundleTreatedAsShuttingDown() throws Exception {
+        OakDiscoveryService ds = new OakDiscoveryService();
+
+        Bundle systemBundleMock = mock(Bundle.class);
+        when(systemBundleMock.getState()).thenThrow(new IllegalStateException("bundle invalidated"));
+        ds.setSystemBundleForTesting(systemBundleMock);
+
+        assertTrue(ds.isShuttingDown());
+    }
+
+    /**
+     * If our BundleContext is already invalidated at activation,
+     * cacheSystemBundle latches {@code deactivating} immediately.
+     */
+    @Test
+    public void testCacheSystemBundleWithInvalidatedContextLatchesDeactivating() {
+        OakDiscoveryService ds = new OakDiscoveryService();
+
+        assertFalse(ds.isShuttingDown());
+
+        Bundle ourBundleMock = mock(Bundle.class);
+        when(ourBundleMock.getBundleContext())
+                .thenThrow(new IllegalStateException("our context invalidated"));
+
+        ds.cacheSystemBundle(ourBundleMock);
+
+        assertTrue(ds.isShuttingDown());
+    }
+
+    /**
+     * End-to-end: with the service still activated but the system bundle
+     * STOPPING, PropertyProvider callbacks must not reach the
+     * ResourceResolverFactory.
+     */
+    @Test
+    public void testActivatedServiceSkipsResourceResolverWhenSystemBundleStopping() throws Exception {
+        OakVirtualInstanceBuilder builder = (OakVirtualInstanceBuilder) new OakVirtualInstanceBuilder()
+                .setDebugName("shutdown-rrf-guard")
+                .newRepository("/foo/shutdown-rrf/", true)
+                .setConnectorPingInterval(999999)
+                .setConnectorPingTimeout(999999);
+        builder.getConfig().setSuppressPartiallyStartedInstance(true);
+        VirtualInstance instance = builder.build();
+        try {
+            OakDiscoveryService ds = (OakDiscoveryService) instance.getDiscoveryService();
+
+            assertFalse(ds.isShuttingDown());
+
+            ResourceResolverFactory rrfMock = mock(ResourceResolverFactory.class);
+            Field rrfField = OakDiscoveryService.class.getDeclaredField("resourceResolverFactory");
+            rrfField.setAccessible(true);
+            rrfField.set(ds, rrfMock);
+
+            Bundle systemBundleMock = mock(Bundle.class);
+            when(systemBundleMock.getState()).thenReturn(Bundle.STOPPING);
+            ds.setSystemBundleForTesting(systemBundleMock);
+
+            // Do NOT pre-latch by calling isShuttingDown() here - the guard
+            // inside doUpdateProperties() must be the one to short-circuit,
+            // otherwise removing that guard would still leave the test green.
+
+            PropertyProviderImpl provider = new PropertyProviderImpl();
+            Map<String, Object> props = new HashMap<>();
+            props.put(Constants.SERVICE_ID, 42L);
+            ds.bindPropertyProvider(provider, props);
+            ds.updatedPropertyProvider(provider, props);
+            ds.unbindPropertyProvider(provider, props);
+
+            verifyNoInteractions(rrfMock);
+        } finally {
+            instance.stop();
+        }
     }
 
     @Test

--- a/src/test/java/org/apache/sling/discovery/oak/OakDiscoveryServiceTest.java
+++ b/src/test/java/org/apache/sling/discovery/oak/OakDiscoveryServiceTest.java
@@ -66,6 +66,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -500,7 +501,7 @@ public class OakDiscoveryServiceTest {
      * deactivate() runs, and latches on first observation.
      */
     @Test
-    public void testInlineSystemBundleStateFallback() throws Exception {
+    public void testInlineSystemBundleStateFallback() {
         OakDiscoveryService ds = new OakDiscoveryService();
 
         Bundle systemBundleMock = mock(Bundle.class);
@@ -522,7 +523,7 @@ public class OakDiscoveryServiceTest {
      * getState) is treated as shutting down.
      */
     @Test
-    public void testInvalidatedSystemBundleTreatedAsShuttingDown() throws Exception {
+    public void testInvalidatedSystemBundleTreatedAsShuttingDown() {
         OakDiscoveryService ds = new OakDiscoveryService();
 
         Bundle systemBundleMock = mock(Bundle.class);
@@ -549,6 +550,84 @@ public class OakDiscoveryServiceTest {
         ds.cacheSystemBundle(ourBundleMock);
 
         assertTrue(ds.isShuttingDown());
+    }
+
+    /**
+     * Happy path: cacheSystemBundle resolves the system bundle via our
+     * BundleContext and subsequent isShuttingDown() calls consult it.
+     */
+    @Test
+    public void testCacheSystemBundleHappyPath() {
+        OakDiscoveryService ds = new OakDiscoveryService();
+
+        Bundle systemBundleMock = mock(Bundle.class);
+        when(systemBundleMock.getState()).thenReturn(Bundle.ACTIVE);
+
+        BundleContext ctxMock = mock(BundleContext.class);
+        when(ctxMock.getBundle(0)).thenReturn(systemBundleMock);
+
+        Bundle ourBundleMock = mock(Bundle.class);
+        when(ourBundleMock.getBundleContext()).thenReturn(ctxMock);
+
+        ds.cacheSystemBundle(ourBundleMock);
+
+        assertFalse(ds.isShuttingDown());
+
+        when(systemBundleMock.getState()).thenReturn(Bundle.STOPPING);
+        assertTrue(ds.isShuttingDown());
+    }
+
+    /**
+     * If our BundleContext is null (bundle stopped mid-activation),
+     * cacheSystemBundle degrades silently: no latch, no NPE.
+     */
+    @Test
+    public void testCacheSystemBundleWithNullBundleContext() {
+        OakDiscoveryService ds = new OakDiscoveryService();
+
+        Bundle ourBundleMock = mock(Bundle.class);
+        when(ourBundleMock.getBundleContext()).thenReturn(null);
+
+        ds.cacheSystemBundle(ourBundleMock);
+
+        assertFalse(ds.isShuttingDown());
+    }
+
+    /**
+     * A non-IllegalStateException RuntimeException from getBundleContext()
+     * is logged and swallowed - shutdown detection degrades to deactivate()
+     * only, but the service does not latch as shutting down.
+     */
+    @Test
+    public void testCacheSystemBundleWithGenericRuntimeException() {
+        OakDiscoveryService ds = new OakDiscoveryService();
+
+        Bundle ourBundleMock = mock(Bundle.class);
+        when(ourBundleMock.getBundleContext())
+                .thenThrow(new SecurityException("denied"));
+
+        ds.cacheSystemBundle(ourBundleMock);
+
+        assertFalse(ds.isShuttingDown());
+    }
+
+    /**
+     * All non-live system bundle states (RESOLVED, INSTALLED, UNINSTALLED)
+     * are treated as shutting down, not just STOPPING.
+     */
+    @Test
+    public void testInlineSystemBundleStateFallbackAllTerminalStates() {
+        int[] terminalStates = { Bundle.RESOLVED, Bundle.INSTALLED, Bundle.UNINSTALLED };
+        for (int state : terminalStates) {
+            OakDiscoveryService ds = new OakDiscoveryService();
+
+            Bundle systemBundleMock = mock(Bundle.class);
+            when(systemBundleMock.getState()).thenReturn(state);
+            ds.setSystemBundleForTesting(systemBundleMock);
+
+            assertTrue("state " + state + " should be treated as shutting down",
+                    ds.isShuttingDown());
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

`OakDiscoveryService.doUpdateProperties()` can block the Felix start-level thread indefinitely on Oak's `CommitQueue` during framework shutdown. When a `PropertyProvider` unbind/update callback fires (from a higher-start-level bundle that stops before `discovery.oak`), DS invokes the callback synchronously on the Felix start-level thread. That callback calls `ResourceResolver.commit()`, which parks on a `CountDownLatch` inside `CommitQueue` and never returns. The JVM only exits when forcibly killed by the surrounding process manager; during that window the instance remains visible in the discovery topology, delaying cluster convergence.

The fix introduces a `volatile boolean deactivating` flag that short-circuits `doUpdateProperties()` before any repository traffic begins, latched from two triggers:

1. **First line of `deactivate()`** — covers standalone component deactivation.
2. **Inline poll of the system bundle state** inside `isShuttingDown()` — covers the observed failure path where `deactivate()` is never reached. Per the OSGi spec the system bundle transitions to `STOPPING` before any other bundle begins stopping, so the poll sees it on the very first guarded callback.

The system bundle reference is cached at activation via `FrameworkUtil.getBundle(...)` so unit tests without an OSGi runtime degrade cleanly to the `deactivate()`-only path.

The fix does **not** interrupt an in-flight commit — it only prevents new commits from starting once shutdown has begun.

## Tests

- `testIsShuttingDownAfterDeactivate` — deactivate flips the flag; subsequent callbacks succeed without touching the repository.
- `testInlineSystemBundleStateFallback` — system bundle `STOPPING` state latches the flag without `deactivate()` being called (the primary failure path).
- `testInvalidatedSystemBundleTreatedAsShuttingDown` — `IllegalStateException` from `getState()` is treated as shutting down.
- `testCacheSystemBundleWithInvalidatedContextLatchesDeactivating` — `IllegalStateException` from `getBundleContext()` at activation latches `deactivating` immediately.
- `testActivatedServiceSkipsResourceResolverWhenSystemBundleStopping` — main acceptance criterion: `Mockito.verifyNoInteractions(rrfMock)` confirms no repository write is attempted once the system bundle is `STOPPING`, even with the service fully activated.

All 22 tests pass (`OakDiscoveryServiceTest` + `its.OakDiscoveryServiceTest`).

## Related

- SLING-5382, SLING-3389, SLING-10204