### PR TITLE
SLING-13286 - OakDiscoveryService: refactor doUpdateProperties for readability

### DIFF
--- a/src/main/java/org/apache/sling/discovery/oak/OakDiscoveryService.java
+++ b/src/main/java/org/apache/sling/discovery/oak/OakDiscoveryService.java
@@ -488,21 +488,29 @@ public class OakDiscoveryService extends BaseDiscoveryService {
         final Config c = config;
         final String sid = slingId;
         if (rrf == null || c == null || sid == null) {
-            // cannot update the properties then..
             logger.debug("doUpdateProperties: too early to update the properties. "
                             + "resourceResolverFactory ({}), config ({}) or slingId ({}) not yet set.",
                     new Object[]{rrf, c, sid});
             return;
-        } else {
-            logger.debug("doUpdateProperties: updating properties now..");
         }
+        logger.debug("doUpdateProperties: updating properties now..");
 
+        persistProperties(rrf, c, sid, collectProviderProperties());
+
+        logger.debug("doUpdateProperties: updating properties done.");
+    }
+
+    private Map<String, String> collectProviderProperties() {
         final Map<String, String> newProps = new HashMap<>();
         for (final ProviderInfo info : this.providerInfos) {
             info.refreshProperties();
             newProps.putAll(info.properties);
         }
+        return newProps;
+    }
 
+    private void persistProperties(final ResourceResolverFactory rrf, final Config c, final String sid,
+                                   final Map<String, String> newProps) {
         ResourceResolver resourceResolver = null;
         try {
             resourceResolver = rrf.getServiceResourceResolver(null);
@@ -515,53 +523,54 @@ public class OakDiscoveryService extends BaseDiscoveryService {
             resourceResolver.refresh();
 
             final ModifiableValueMap myInstanceMap = myInstance.adaptTo(ModifiableValueMap.class);
-            final Set<String> keys = new HashSet<String>(myInstanceMap.keySet());
-            for (final String key : keys) {
-                if (newProps.containsKey(key)) {
-                    // perfect
-                    continue;
-                } else if (key.indexOf(":") != -1) {
-                    // ignore
-                    continue;
-                } else {
-                    // remove
-                    myInstanceMap.remove(key);
-                }
-            }
-
-            boolean anyChanges = false;
-            for (final Entry<String, String> entry : newProps.entrySet()) {
-                Object existingValue = myInstanceMap.get(entry.getKey());
-                if (entry.getValue().equals(existingValue)) {
-                    // SLING-3389: dont rewrite the properties if nothing changed!
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("doUpdateProperties: unchanged: {}={}", entry.getKey(), entry.getValue());
-                    }
-                    continue;
-                }
-                if (logger.isDebugEnabled()) {
-                    logger.debug("doUpdateProperties: changed: {}={}", entry.getKey(), entry.getValue());
-                }
-                anyChanges = true;
-                myInstanceMap.put(entry.getKey(), entry.getValue());
-            }
-
-            if (anyChanges) {
+            removeStaleKeys(myInstanceMap, newProps.keySet());
+            if (applyNewProperties(myInstanceMap, newProps)) {
                 resourceResolver.commit();
             }
         } catch (LoginException e) {
-            logger.error("handleEvent: could not log in administratively: " + e, e);
+            logger.error("doUpdateProperties: could not log in administratively: " + e, e);
             throw new RuntimeException("Could not log in to repository (" + e + ")", e);
         } catch (PersistenceException e) {
-            logger.error("handleEvent: got a PersistenceException: " + e, e);
-            throw new RuntimeException( "Exception while talking to repository (" + e + ")", e);
+            logger.error("doUpdateProperties: got a PersistenceException: " + e, e);
+            throw new RuntimeException("Exception while talking to repository (" + e + ")", e);
         } finally {
             if (resourceResolver != null) {
                 resourceResolver.close();
             }
         }
+    }
 
-        logger.debug("doUpdateProperties: updating properties done.");
+    private void removeStaleKeys(final ModifiableValueMap map, final Set<String> newKeys) {
+        for (final String key : new HashSet<>(map.keySet())) {
+            if (newKeys.contains(key)) {
+                continue;
+            }
+            if (key.indexOf(':') != -1) {
+                // ignore namespaced keys
+                continue;
+            }
+            map.remove(key);
+        }
+    }
+
+    private boolean applyNewProperties(final ModifiableValueMap map, final Map<String, String> newProps) {
+        boolean anyChanges = false;
+        for (final Entry<String, String> entry : newProps.entrySet()) {
+            Object existingValue = map.get(entry.getKey());
+            if (entry.getValue().equals(existingValue)) {
+                // SLING-3389: dont rewrite the properties if nothing changed!
+                if (logger.isDebugEnabled()) {
+                    logger.debug("applyNewProperties: unchanged: {}={}", entry.getKey(), entry.getValue());
+                }
+                continue;
+            }
+            if (logger.isDebugEnabled()) {
+                logger.debug("applyNewProperties: changed: {}={}", entry.getKey(), entry.getValue());
+            }
+            anyChanges = true;
+            map.put(entry.getKey(), entry.getValue());
+        }
+        return anyChanges;
     }
 
     /**

--- a/src/main/java/org/apache/sling/discovery/oak/OakDiscoveryService.java
+++ b/src/main/java/org/apache/sling/discovery/oak/OakDiscoveryService.java
@@ -28,6 +28,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.locks.ReentrantLock;
@@ -520,7 +521,9 @@ public class OakDiscoveryService extends BaseDiscoveryService {
             resourceResolver.revert();
             resourceResolver.refresh();
 
-            final ModifiableValueMap myInstanceMap = myInstance.adaptTo(ModifiableValueMap.class);
+            final ModifiableValueMap myInstanceMap = Objects.requireNonNull(
+                    myInstance.adaptTo(ModifiableValueMap.class),
+                    "adaptTo(ModifiableValueMap.class) returned null");
             removeStaleKeys(myInstanceMap, newProps.keySet());
             if (applyNewProperties(myInstanceMap, newProps)) {
                 resourceResolver.commit();

--- a/src/main/java/org/apache/sling/discovery/oak/OakDiscoveryService.java
+++ b/src/main/java/org/apache/sling/discovery/oak/OakDiscoveryService.java
@@ -542,14 +542,10 @@ public class OakDiscoveryService extends BaseDiscoveryService {
 
     private void removeStaleKeys(final ModifiableValueMap map, final Set<String> newKeys) {
         for (final String key : new HashSet<>(map.keySet())) {
-            if (newKeys.contains(key)) {
-                continue;
+            // skip keys still present in newKeys, and namespaced keys
+            if (!newKeys.contains(key) && key.indexOf(':') == -1) {
+                map.remove(key);
             }
-            if (key.indexOf(':') != -1) {
-                // ignore namespaced keys
-                continue;
-            }
-            map.remove(key);
         }
     }
 

--- a/src/main/java/org/apache/sling/discovery/oak/OakDiscoveryService.java
+++ b/src/main/java/org/apache/sling/discovery/oak/OakDiscoveryService.java
@@ -526,10 +526,10 @@ public class OakDiscoveryService extends BaseDiscoveryService {
                 resourceResolver.commit();
             }
         } catch (LoginException e) {
-            logger.error("persistProperties: could not log in administratively: " + e, e);
+            logger.error("persistProperties: could not log in administratively: {}", e, e);
             throw new RuntimeException("Could not log in to repository (" + e + ")", e);
         } catch (PersistenceException e) {
-            logger.error("persistProperties: got a PersistenceException: " + e, e);
+            logger.error("persistProperties: got a PersistenceException: {}", e, e);
             throw new RuntimeException("Exception while talking to repository (" + e + ")", e);
         }
     }

--- a/src/main/java/org/apache/sling/discovery/oak/OakDiscoveryService.java
+++ b/src/main/java/org/apache/sling/discovery/oak/OakDiscoveryService.java
@@ -511,9 +511,7 @@ public class OakDiscoveryService extends BaseDiscoveryService {
 
     private void persistProperties(final ResourceResolverFactory rrf, final Config c, final String sid,
                                    final Map<String, String> newProps) {
-        ResourceResolver resourceResolver = null;
-        try {
-            resourceResolver = rrf.getServiceResourceResolver(null);
+        try (ResourceResolver resourceResolver = rrf.getServiceResourceResolver(null)) {
 
             Resource myInstance = ResourceHelper
                     .getOrCreateResource(resourceResolver, c.getClusterInstancesPath() + "/" + sid + "/properties");
@@ -528,15 +526,11 @@ public class OakDiscoveryService extends BaseDiscoveryService {
                 resourceResolver.commit();
             }
         } catch (LoginException e) {
-            logger.error("doUpdateProperties: could not log in administratively: " + e, e);
+            logger.error("persistProperties: could not log in administratively: " + e, e);
             throw new RuntimeException("Could not log in to repository (" + e + ")", e);
         } catch (PersistenceException e) {
-            logger.error("doUpdateProperties: got a PersistenceException: " + e, e);
+            logger.error("persistProperties: got a PersistenceException: " + e, e);
             throw new RuntimeException("Exception while talking to repository (" + e + ")", e);
-        } finally {
-            if (resourceResolver != null) {
-                resourceResolver.close();
-            }
         }
     }
 


### PR DESCRIPTION
## Summary

Refactors `OakDiscoveryService.doUpdateProperties()` — a ~65-line "brain method" that mixed
precondition checks, provider-property collection, resource-resolver lifecycle management,
stale-key removal, and change detection — into small, single-purpose helpers. No behavior
change intended; the commits are staged so each is independently reviewable.

### Commits

1. Extract helpers to fix brain-method metrics (`77ab3b9`)
2. Simplify `removeStaleKeys` condition (`266c8a3`)
3. Use try-with-resources in `persistProperties` (`dffb1ac`)
4. Use SLF4J parameterized logging in `persistProperties` (`221847c`)
5. Null-check `ModifiableValueMap` from `adaptTo` (`bd78248`)
